### PR TITLE
Remove erlang:get_stacktrace/0

### DIFF
--- a/src/cowboy.app.src
+++ b/src/cowboy.app.src
@@ -1,6 +1,6 @@
 {application, cowboy,
  [{description, "Small, fast, modern HTTP server."},
-  {vsn, "2.8.2"},
+  {vsn, "git"},
   {modules, []},
   {registered, [cowboy_sup,cowboy_clock]},
   {applications, [kernel,stdlib,crypto,cowlib,ranch]},

--- a/src/cowboy.appup.src
+++ b/src/cowboy.appup.src
@@ -1,12 +1,32 @@
 %% -*-: erlang -*-
 
-{VSN,
+{"2.8.3",
   [
+    {"2.8.2", [
+      {load_module, cowboy_handler, brutal_purge, soft_purge, []},
+      {load_module, cowboy_http, brutal_purge, soft_purge, []},
+      {load_module, cowboy_http2, brutal_purge, soft_purge, []},
+      {load_module, cowboy_loop, brutal_purge, soft_purge, []},
+      {load_module, cowboy_req, brutal_purge, soft_purge, []},
+      {load_module, cowboy_rest, brutal_purge, soft_purge, []},
+      {load_module, cowboy_stream_h, brutal_purge, soft_purge, []},
+      {load_module, cowboy_websocket, brutal_purge, soft_purge, []}
+    ]},
     {"2.8.1", [
       {load_module, cowboy_clear, brutal_purge, soft_purge, []}
     ]}
   ],
   [
+    {"2.8.2", [
+      {load_module, cowboy_handler, brutal_purge, soft_purge, []},
+      {load_module, cowboy_http, brutal_purge, soft_purge, []},
+      {load_module, cowboy_http2, brutal_purge, soft_purge, []},
+      {load_module, cowboy_loop, brutal_purge, soft_purge, []},
+      {load_module, cowboy_req, brutal_purge, soft_purge, []},
+      {load_module, cowboy_rest, brutal_purge, soft_purge, []},
+      {load_module, cowboy_stream_h, brutal_purge, soft_purge, []},
+      {load_module, cowboy_websocket, brutal_purge, soft_purge, []}
+    ]},
     {"2.8.1", [
       {load_module, cowboy_clear, brutal_purge, soft_purge, []}
     ]}

--- a/src/cowboy_handler.erl
+++ b/src/cowboy_handler.erl
@@ -46,10 +46,10 @@ execute(Req, Env=#{handler := Handler, handler_opts := HandlerOpts}) ->
 			Mod:upgrade(Req2, Env, Handler, State);
 		{Mod, Req2, State, Opts} ->
 			Mod:upgrade(Req2, Env, Handler, State, Opts)
-	catch Class:Reason ->
-		StackTrace = erlang:get_stacktrace(),
+	catch Class:Reason:ST ->
+		logger:error("cowboy execute Handler:init/2 crashed with: ~p", [{Class, Reason, ST}]),
 		terminate({crash, Class, Reason}, Req, HandlerOpts, Handler),
-		erlang:raise(Class, Reason, StackTrace)
+		erlang:raise(Class, Reason, ST)
 	end.
 
 -spec terminate(any(), Req | undefined, any(), module()) -> ok when Req::cowboy_req:req().

--- a/src/cowboy_handler.erl
+++ b/src/cowboy_handler.erl
@@ -47,7 +47,6 @@ execute(Req, Env=#{handler := Handler, handler_opts := HandlerOpts}) ->
 		{Mod, Req2, State, Opts} ->
 			Mod:upgrade(Req2, Env, Handler, State, Opts)
 	catch Class:Reason:ST ->
-		logger:error("cowboy execute Handler:init/2 crashed with: ~p", [{Class, Reason, ST}]),
 		terminate({crash, Class, Reason}, Req, HandlerOpts, Handler),
 		erlang:raise(Class, Reason, ST)
 	end.

--- a/src/cowboy_http.erl
+++ b/src/cowboy_http.erl
@@ -335,10 +335,10 @@ after_parse({request, Req=#{streamid := StreamID, method := Method,
 			end,
 			State = set_timeout(State1, idle_timeout),
 			parse(Buffer, commands(State, StreamID, Commands))
-	catch Class:Exception ->
+	catch Class:Exception:ST ->
 		cowboy:log(cowboy_stream:make_error_log(init,
 			[StreamID, Req, Opts],
-			Class, Exception, erlang:get_stacktrace()), Opts),
+			Class, Exception, ST), Opts),
 		early_error(500, State0, {internal_error, {Class, Exception},
 			'Unhandled exception in cowboy_stream:init/3.'}, Req),
 		parse(Buffer, State0)
@@ -357,10 +357,10 @@ after_parse({data, StreamID, IsFin, Data, State0=#state{opts=Opts, buffer=Buffer
 			end),
 			State = update_flow(IsFin, Data, State1#state{streams=Streams}),
 			parse(Buffer, commands(State, StreamID, Commands))
-	catch Class:Exception ->
+	catch Class:Exception:ST ->
 		cowboy:log(cowboy_stream:make_error_log(data,
 			[StreamID, IsFin, Data, StreamState0],
-			Class, Exception, erlang:get_stacktrace()), Opts),
+			Class, Exception, ST), Opts),
 		%% @todo Should call parse after this.
 		stream_terminate(State0, StreamID, {internal_error, {Class, Exception},
 			'Unhandled exception in cowboy_stream:data/4.'})
@@ -904,10 +904,10 @@ info(State=#state{opts=Opts, streams=Streams0}, StreamID, Msg) ->
 					Streams = lists:keyreplace(StreamID, #stream.id, Streams0,
 						Stream#stream{state=StreamState}),
 					commands(State#state{streams=Streams}, StreamID, Commands)
-			catch Class:Exception ->
+			catch Class:Exception:ST ->
 				cowboy:log(cowboy_stream:make_error_log(info,
 					[StreamID, Msg, StreamState0],
-					Class, Exception, erlang:get_stacktrace()), Opts),
+					Class, Exception, ST), Opts),
 				stream_terminate(State, StreamID, {internal_error, {Class, Exception},
 					'Unhandled exception in cowboy_stream:info/3.'})
 			end;
@@ -1286,10 +1286,10 @@ stream_terminate(State0=#state{opts=Opts, in_streamid=InStreamID, in_state=InSta
 stream_call_terminate(StreamID, Reason, StreamState, #state{opts=Opts}) ->
 	try
 		cowboy_stream:terminate(StreamID, Reason, StreamState)
-	catch Class:Exception ->
+	catch Class:Exception:ST ->
 		cowboy:log(cowboy_stream:make_error_log(terminate,
 			[StreamID, Reason, StreamState],
-			Class, Exception, erlang:get_stacktrace()), Opts)
+			Class, Exception, ST), Opts)
 	end.
 
 maybe_req_close(#state{opts=#{http10_keepalive := false}}, _, 'HTTP/1.0') ->
@@ -1386,10 +1386,10 @@ early_error(StatusCode0, #state{socket=Socket, transport=Transport,
 				%% @todo Technically we allow the sendfile tuple.
 				RespBody
 			])
-	catch Class:Exception ->
+	catch Class:Exception:ST ->
 		cowboy:log(cowboy_stream:make_error_log(early_error,
 			[StreamID, Reason, PartialReq, Resp, Opts],
-			Class, Exception, erlang:get_stacktrace()), Opts),
+			Class, Exception, ST), Opts),
 		%% We still need to send an error response, so send what we initially
 		%% wanted to send. It's better than nothing.
 		Transport:send(Socket, cow_http:response(StatusCode0,

--- a/src/cowboy_http2.erl
+++ b/src/cowboy_http2.erl
@@ -384,10 +384,10 @@ data_frame(State0=#state{opts=Opts, flow=Flow, streams=Streams}, StreamID, IsFin
 							flow=max(0, StreamFlow - Size), state=StreamState}}},
 						StreamID),
 					commands(State, StreamID, Commands)
-			catch Class:Exception ->
+			catch Class:Exception:ST ->
 				cowboy:log(cowboy_stream:make_error_log(data,
 					[StreamID, IsFin, Data, StreamState0],
-					Class, Exception, erlang:get_stacktrace()), Opts),
+					Class, Exception, ST), Opts),
 				reset_stream(State0, StreamID, {internal_error, {Class, Exception},
 					'Unhandled exception in cowboy_stream:data/4.'})
 			end;
@@ -491,10 +491,10 @@ headers_frame(State=#state{opts=Opts, streams=Streams}, StreamID, Req) ->
 			commands(State#state{
 				streams=Streams#{StreamID => #stream{state=StreamState}}},
 				StreamID, Commands)
-	catch Class:Exception ->
+	catch Class:Exception:ST ->
 		cowboy:log(cowboy_stream:make_error_log(init,
 			[StreamID, Req, Opts],
-			Class, Exception, erlang:get_stacktrace()), Opts),
+			Class, Exception, ST), Opts),
 		reset_stream(State, StreamID, {internal_error, {Class, Exception},
 			'Unhandled exception in cowboy_stream:init/3.'})
 	end.
@@ -518,10 +518,10 @@ early_error(State0=#state{ref=Ref, opts=Opts, peer=Peer},
 	try cowboy_stream:early_error(StreamID, Reason, PartialReq, Resp, Opts) of
 		{response, StatusCode, RespHeaders, RespBody} ->
 			send_response(State0, StreamID, StatusCode, RespHeaders, RespBody)
-	catch Class:Exception ->
+	catch Class:Exception:ST ->
 		cowboy:log(cowboy_stream:make_error_log(early_error,
 			[StreamID, Reason, PartialReq, Resp, Opts],
-			Class, Exception, erlang:get_stacktrace()), Opts),
+			Class, Exception, ST), Opts),
 		%% We still need to send an error response, so send what we initially
 		%% wanted to send. It's better than nothing.
 		send_headers(State0, StreamID, fin, StatusCode0, RespHeaders0)
@@ -579,10 +579,10 @@ info(State=#state{opts=Opts, http2_machine=HTTP2Machine, streams=Streams}, Strea
 				{Commands, StreamState} ->
 					commands(State#state{streams=Streams#{StreamID => Stream#stream{state=StreamState}}},
 						StreamID, Commands)
-			catch Class:Exception ->
+			catch Class:Exception:ST ->
 				cowboy:log(cowboy_stream:make_error_log(info,
 					[StreamID, Msg, StreamState0],
-					Class, Exception, erlang:get_stacktrace()), Opts),
+					Class, Exception, ST), Opts),
 				reset_stream(State, StreamID, {internal_error, {Class, Exception},
 					'Unhandled exception in cowboy_stream:info/3.'})
 			end;
@@ -1030,10 +1030,10 @@ terminate_stream(State=#state{flow=Flow, streams=Streams0, children=Children0}, 
 terminate_stream_handler(#state{opts=Opts}, StreamID, Reason, StreamState) ->
 	try
 		cowboy_stream:terminate(StreamID, Reason, StreamState)
-	catch Class:Exception ->
+	catch Class:Exception:ST ->
 		cowboy:log(cowboy_stream:make_error_log(terminate,
 			[StreamID, Reason, StreamState],
-			Class, Exception, erlang:get_stacktrace()), Opts)
+			Class, Exception, ST), Opts)
 	end.
 
 %% System callbacks.

--- a/src/cowboy_loop.erl
+++ b/src/cowboy_loop.erl
@@ -81,10 +81,9 @@ call(Req0, Env, Handler, HandlerState0, Message) ->
 			suspend(Req, Env, Handler, HandlerState);
 		{stop, Req, HandlerState} ->
 			terminate(Req, Env, Handler, HandlerState, stop)
-	catch Class:Reason ->
-		StackTrace = erlang:get_stacktrace(),
+	catch Class:Reason:ST ->
 		cowboy_handler:terminate({crash, Class, Reason}, Req0, HandlerState0, Handler),
-		erlang:raise(Class, Reason, StackTrace)
+		erlang:raise(Class, Reason, ST)
 	end.
 
 suspend(Req, Env, Handler, HandlerState) ->

--- a/src/cowboy_req.erl
+++ b/src/cowboy_req.erl
@@ -224,10 +224,10 @@ qs(#{qs := Qs}) ->
 parse_qs(#{qs := Qs}) ->
 	try
 		cow_qs:parse_qs(Qs)
-	catch _:_ ->
+	catch _:_:ST ->
 		erlang:raise(exit, {request_error, qs,
 			'Malformed query string; application/x-www-form-urlencoded expected.'
-		}, erlang:get_stacktrace())
+		}, ST)
 	end.
 
 -spec match_qs(cowboy:fields(), req()) -> map().
@@ -415,10 +415,10 @@ parse_header(Name, Req) ->
 parse_header(Name, Req, Default) ->
 	try
 		parse_header(Name, Req, Default, parse_header_fun(Name))
-	catch _:_ ->
+	catch _:_:ST ->
 		erlang:raise(exit, {request_error, {header, Name},
 			'Malformed header. Please consult the relevant specification.'
-		}, erlang:get_stacktrace())
+		}, ST)
 	end.
 
 parse_header_fun(<<"accept">>) -> fun cow_http_hd:parse_accept/1;
@@ -546,10 +546,10 @@ read_urlencoded_body(Req0, Opts) ->
 		{ok, Body, Req} ->
 			try
 				{ok, cow_qs:parse_qs(Body), Req}
-			catch _:_ ->
+			catch _:_:ST ->
 				erlang:raise(exit, {request_error, urlencoded_body,
 					'Malformed body; application/x-www-form-urlencoded expected.'
-				}, erlang:get_stacktrace())
+				}, ST)
 			end;
 		{more, Body, _} ->
 			Length = maps:get(length, Opts, 64000),
@@ -616,10 +616,10 @@ read_part(Buffer, Opts, Req=#{multipart := {Boundary, _}}) ->
 		%% Ignore epilogue.
 		{done, _} ->
 			{done, Req#{multipart => done}}
-	catch _:_ ->
+	catch _:_:ST ->
 		erlang:raise(exit, {request_error, {multipart, headers},
 			'Malformed body; multipart expected.'
-		}, erlang:get_stacktrace())
+		}, ST)
 	end.
 
 -spec read_part_body(Req)

--- a/src/cowboy_rest.erl
+++ b/src/cowboy_rest.erl
@@ -812,8 +812,8 @@ variances(Req, State=#state{content_types_p=CTP,
 						<<"vary">>, [H|Variances5], Req2),
 					resource_exists(Req3, State2)
 			end
-	catch Class:Reason ->
-		error_terminate(Req, State, Class, Reason)
+	catch Class:Reason:ST ->
+		error_terminate(Req, State, Class, Reason, ST)
 	end.
 
 variances(Req, State, Variances) ->
@@ -850,8 +850,8 @@ if_match(Req, State, EtagsList) ->
 				%% Etag may be `undefined' which cannot be a member.
 				false -> precondition_failed(Req2, State2)
 			end
-	catch Class:Reason ->
-		error_terminate(Req, State, Class, Reason)
+	catch Class:Reason:ST ->
+		error_terminate(Req, State, Class, Reason, ST)
 	end.
 
 if_match_must_not_exist(Req, State) ->
@@ -878,8 +878,8 @@ if_unmodified_since(Req, State, IfUnmodifiedSince) ->
 				true -> precondition_failed(Req2, State2);
 				false -> if_none_match_exists(Req2, State2)
 			end
-	catch Class:Reason ->
-		error_terminate(Req, State, Class, Reason)
+	catch Class:Reason:ST ->
+		error_terminate(Req, State, Class, Reason, ST)
 	end.
 
 if_none_match_exists(Req, State) ->
@@ -904,8 +904,8 @@ if_none_match(Req, State, EtagsList) ->
 						false -> method(Req2, State2)
 					end
 			end
-	catch Class:Reason ->
-		error_terminate(Req, State, Class, Reason)
+	catch Class:Reason:ST ->
+		error_terminate(Req, State, Class, Reason, ST)
 	end.
 
 %% Weak Etag comparison: only check the opaque tag.
@@ -947,8 +947,8 @@ if_modified_since(Req, State, IfModifiedSince) ->
 				true -> method(Req2, State2);
 				false -> not_modified(Req2, State2)
 			end
-	catch Class:Reason ->
-		error_terminate(Req, State, Class, Reason)
+	catch Class:Reason:ST ->
+		error_terminate(Req, State, Class, Reason, ST)
 	end.
 
 not_modified(Req, State) ->
@@ -958,11 +958,11 @@ not_modified(Req, State) ->
 			try set_resp_expires(Req3, State2) of
 				{Req4, State3} ->
 					respond(Req4, State3, 304)
-			catch Class:Reason ->
-				error_terminate(Req, State2, Class, Reason)
+			catch Class:Reason:ST ->
+				error_terminate(Req, State2, Class, Reason, ST)
 			end
-	catch Class:Reason ->
-		error_terminate(Req, State, Class, Reason)
+	catch Class:Reason:ST ->
+		error_terminate(Req, State, Class, Reason, ST)
 	end.
 
 precondition_failed(Req, State) ->
@@ -1115,8 +1115,8 @@ process_content_type(Req, State=#state{method=Method, exists=Exists}, Fun) ->
 				Exists -> respond(Req3, State2, 303);
 				true -> respond(Req3, State2, 201)
 			end
-	end catch Class:Reason = {case_clause, no_call} ->
-		error_terminate(Req, State, Class, Reason)
+	end catch Class:Reason = {case_clause, no_call}:ST ->
+		error_terminate(Req, State, Class, Reason, ST)
 	end.
 
 %% If PUT was used then the resource has been created at the current URL.
@@ -1142,8 +1142,8 @@ set_resp_body_etag(Req, State) ->
 	try set_resp_etag(Req, State) of
 		{Req2, State2} ->
 			set_resp_body_last_modified(Req2, State2)
-	catch Class:Reason ->
-		error_terminate(Req, State, Class, Reason)
+	catch Class:Reason:ST ->
+		error_terminate(Req, State, Class, Reason, ST)
 	end.
 
 %% Set the Last-Modified header if any for the response provided.
@@ -1159,8 +1159,8 @@ set_resp_body_last_modified(Req, State) ->
 						<<"last-modified">>, LastModifiedBin, Req2),
 					set_resp_body_expires(Req3, State2)
 			end
-	catch Class:Reason ->
-		error_terminate(Req, State, Class, Reason)
+	catch Class:Reason:ST ->
+		error_terminate(Req, State, Class, Reason, ST)
 	end.
 
 %% Set the Expires header if any for the response provided.
@@ -1168,8 +1168,8 @@ set_resp_body_expires(Req, State) ->
 	try set_resp_expires(Req, State) of
 		{Req2, State2} ->
 			if_range(Req2, State2)
-	catch Class:Reason ->
-		error_terminate(Req, State, Class, Reason)
+	catch Class:Reason:ST ->
+		error_terminate(Req, State, Class, Reason, ST)
 	end.
 
 %% When both the if-range and range headers are set, we perform
@@ -1254,9 +1254,9 @@ set_ranged_body_auto(Req, State=#state{handler=Handler, content_type_a={_, Callb
 			switch_handler(Switch, Req2, State2);
 		{Body, Req2, State2} ->
 			maybe_set_ranged_body_auto(Req2, State2, Body)
-	end catch Class:{case_clause, no_call} ->
+	end catch Class:{case_clause, no_call}:ST ->
 		error_terminate(Req, State, Class, {error, {missing_callback, {Handler, Callback, 2}},
-			'A callback specified in content_types_provided/2 is not exported.'})
+			'A callback specified in content_types_provided/2 is not exported.'}, ST)
 	end.
 
 maybe_set_ranged_body_auto(Req=#{range := {_, Ranges}}, State, Body) ->
@@ -1379,9 +1379,9 @@ set_ranged_body_callback(Req, State=#state{handler=Handler}, Callback) ->
 				true -> send_multipart_ranged_body(Req2, State2, Ranges);
 				false -> set_multipart_ranged_body(Req2, State2, Ranges)
 			end
-	end catch Class:{case_clause, no_call} ->
+	end catch Class:{case_clause, no_call}:ST ->
 		error_terminate(Req, State, Class, {error, {missing_callback, {Handler, Callback, 2}},
-			'A callback specified in ranges_provided/2 is not exported.'})
+			'A callback specified in ranges_provided/2 is not exported.'}, ST)
 	end.
 
 set_one_ranged_body(Req0, State, OneRange) ->
@@ -1471,9 +1471,9 @@ set_resp_body(Req, State=#state{handler=Handler, content_type_a={_, Callback}}) 
 		{Body, Req2, State2} ->
 			Req3 = cowboy_req:set_resp_body(Body, Req2),
 			multiple_choices(Req3, State2)
-	end catch Class:{case_clause, no_call} ->
+	end catch Class:{case_clause, no_call}:ST ->
 		error_terminate(Req, State, Class, {error, {missing_callback, {Handler, Callback, 2}},
-			'A callback specified in content_types_provided/2 is not exported.'})
+			'A callback specified in content_types_provided/2 is not exported.'}, ST)
 	end.
 
 multiple_choices(Req, State) ->
@@ -1578,8 +1578,8 @@ call(Req0, State=#state{handler=Handler,
 					no_call;
 				{Result, Req, HandlerState} ->
 					{Result, Req, State#state{handler_state=HandlerState}}
-			catch Class:Reason ->
-				error_terminate(Req0, State, Class, Reason)
+			catch Class:Reason:ST ->
+				error_terminate(Req0, State, Class, Reason, ST)
 			end;
 		false ->
 			no_call
@@ -1620,9 +1620,9 @@ switch_handler({switch_handler, Mod}, Req, #state{handler_state=HandlerState}) -
 switch_handler({switch_handler, Mod, Opts}, Req, #state{handler_state=HandlerState}) ->
 	{Mod, Req, HandlerState, Opts}.
 
--spec error_terminate(cowboy_req:req(), #state{}, atom(), any()) -> no_return().
-error_terminate(Req, #state{handler=Handler, handler_state=HandlerState}, Class, Reason) ->
-	StackTrace = erlang:get_stacktrace(),
+-spec error_terminate(cowboy_req:req(), #state{}, atom(), any(), any()) -> no_return().
+error_terminate(Req, #state{handler=Handler, handler_state=HandlerState}, Class,
+		Reason, StackTrace) ->
 	cowboy_handler:terminate({crash, Class, Reason}, Req, HandlerState, Handler),
 	erlang:raise(Class, Reason, StackTrace).
 

--- a/src/cowboy_stream_h.erl
+++ b/src/cowboy_stream_h.erl
@@ -301,17 +301,15 @@ request_process(Req, Env, Middlewares) ->
 	try
 		execute(Req, Env, Middlewares)
 	catch
-		exit:Reason ->
-			Stacktrace = erlang:get_stacktrace(),
-			erlang:raise(exit, {Reason, Stacktrace}, Stacktrace);
+		exit:Reason:ST ->
+			erlang:raise(exit, {Reason, ST}, ST);
 		%% OTP 19 does not propagate any exception stacktraces,
 		%% we therefore add it for every class of exception.
-		_:Reason when OTP =:= "19" ->
-			Stacktrace = erlang:get_stacktrace(),
-			erlang:raise(exit, {Reason, Stacktrace}, Stacktrace);
+		_:Reason:ST when OTP =:= "19" ->
+			erlang:raise(exit, {Reason, ST}, ST);
 		%% @todo I don't think this clause is necessary.
-		Class:Reason ->
-			erlang:raise(Class, Reason, erlang:get_stacktrace())
+		Class:Reason:ST ->
+			erlang:raise(Class, Reason, ST)
 	end.
 
 execute(_, _, []) ->

--- a/src/cowboy_websocket.erl
+++ b/src/cowboy_websocket.erl
@@ -522,8 +522,8 @@ handler_call(State=#state{handler=Handler}, HandlerState,
 			end;
 		{stop, HandlerState2} ->
 			websocket_close(State, HandlerState2, stop)
-	catch Class:Reason ->
-		StackTrace = erlang:get_stacktrace(),
+	catch Class:Reason:ST ->
+		StackTrace = ST,
 		websocket_send_close(State, {crash, Class, Reason}),
 		handler_terminate(State, HandlerState, {crash, Class, Reason}),
 		erlang:raise(Class, Reason, StackTrace)


### PR DESCRIPTION
> The erlang:get_stacktrace/0 is deprecated and will be removed in OTP 24.
> Starting from OTP 23, erlang:get_stacktrace/0 returns [].