### PR TITLE
Fix case clause in cowboy_websocket.erl

### DIFF
--- a/src/cowboy.appup.src
+++ b/src/cowboy.appup.src
@@ -1,7 +1,10 @@
 %% -*-: erlang -*-
 
-{"2.9.0",
-  [{<<"2\\.8\\..*">>,[
+{"2.9.1",
+  [{"2.9.0",[
+      {load_module,cowboy_websocket,brutal_purge,soft_purge,[]}
+    ]},
+   {<<"2\\.8\\..*">>,[
       {load_module,cowboy_handler,brutal_purge,soft_purge,[]},
       {load_module,cowboy_http,brutal_purge,soft_purge,[]},
       {load_module,cowboy_http2,brutal_purge,soft_purge,[]},
@@ -13,7 +16,10 @@
     ]},
    {<<".*">>, []}
   ],
-  [{<<"2\\.8\\..*">>,[
+  [{"2.9.0",[
+      {load_module,cowboy_websocket,brutal_purge,soft_purge,[]}
+    ]},
+   {<<"2\\.8\\..*">>,[
       {load_module,cowboy_handler,brutal_purge,soft_purge,[]},
       {load_module,cowboy_http,brutal_purge,soft_purge,[]},
       {load_module,cowboy_http2,brutal_purge,soft_purge,[]},

--- a/src/cowboy_websocket.erl
+++ b/src/cowboy_websocket.erl
@@ -640,7 +640,7 @@ websocket_send_close(State, Reason) ->
 	_ = case Reason of
 		Normal when is_atom(Normal) ->
 			transport_send(State, fin, frame({close, 1000, <<>>}, State));
-        {error, close} ->
+        {error, closed} ->
 			transport_send(State, fin, frame({close, 1000, <<>>}, State));
 		{error, badframe} ->
 			transport_send(State, fin, frame({close, 1002, <<>>}, State));


### PR DESCRIPTION
Sometimes we got following errors:

```
{case_clause, {error, closed}}
```

We tried to fix this in PR: https://github.com/emqx/cowboy/pull/3 but it should be `closed` not `close`.
