### PR TITLE
Incorrect default idle timeout

### DIFF
--- a/src/cowboy.appup.src
+++ b/src/cowboy.appup.src
@@ -1,7 +1,11 @@
 %% -*-: erlang -*-
 
-{"2.9.2",
-  [{"2.9.0",[
+{"2.9.3",
+  [{"2.9.2",[
+      {load_module,cowboy_http,brutal_purge,soft_purge,[]}
+    ]},
+   {"2.9.0",[
+      {load_module,cowboy_http,brutal_purge,soft_purge,[]},
       {load_module,cowboy_websocket,brutal_purge,soft_purge,[]}
     ]},
    {<<"2\\.8\\..*">>,[
@@ -16,7 +20,11 @@
     ]},
    {<<".*">>, []}
   ],
-  [{"2.9.0",[
+  [{"2.9.2",[
+      {load_module,cowboy_http,brutal_purge,soft_purge,[]}
+    ]},
+   {"2.9.0",[
+      {load_module,cowboy_http,brutal_purge,soft_purge,[]},
       {load_module,cowboy_websocket,brutal_purge,soft_purge,[]}
     ]},
    {<<"2\\.8\\..*">>,[

--- a/src/cowboy_http.erl
+++ b/src/cowboy_http.erl
@@ -1252,12 +1252,10 @@ stream_terminate(State0=#state{opts=Opts, in_streamid=InStreamID, in_state=InSta
 	%% Remove the stream from the state and reset the overriden options.
 	{value, #stream{state=StreamState}, Streams}
 		= lists:keytake(StreamID, #stream.id, Streams1),
-	State2 = State1#state{streams=Streams, overriden_opts=#{}, flow=infinity},
 	%% Stop the stream.
-	stream_call_terminate(StreamID, Reason, StreamState, State2),
+	stream_call_terminate(StreamID, Reason, StreamState, State1),
 	Children = cowboy_children:shutdown(Children0, StreamID),
-	%% We reset the timeout if there are no active streams anymore.
-	State = set_timeout(State2#state{streams=Streams, children=Children}, request_timeout),
+	State = State1#state{overriden_opts=#{}, streams=Streams, children=Children},
 	%% We want to drop the connection if the body was not read fully
 	%% and we don't know its length or more remains to be read than
 	%% configuration allows.


### PR DESCRIPTION
The idle timeout of HTTP listeners should be 60s, but it is now 5s in our tests, because the timers are reset in the `stream_terminate/3` of the `cowboy_http` module.

The changes are copied from the upstream cowboy repo: https://github.com/ninenines/cowboy/blob/9e600f6c1df3c440bc196b66ebbc005d70107217/src/cowboy_http.erl#L1292