### PR TITLE
fix(ws-linger): avoid passing socket error to `websocket_close/3`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ CT_OPTS += -ct_hooks cowboy_ct_hook [] # -boot start_sasl
 LOCAL_DEPS = crypto
 
 DEPS = cowlib ranch
-dep_cowlib = git https://github.com/ninenines/cowlib 2.14.0
+dep_cowlib = git https://github.com/ninenines/cowlib 2.15.0
 dep_ranch = git https://github.com/ninenines/ranch 1.8.1
 
 ifeq ($(COWBOY_QUICER),1)

--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,4 @@
 {deps, [
-{cowlib,".*",{git,"https://github.com/ninenines/cowlib",{tag,"2.14.0"}}},{ranch,".*",{git,"https://github.com/ninenines/ranch",{tag,"1.8.1"}}}
+{cowlib,".*",{git,"https://github.com/ninenines/cowlib",{tag,"2.15.0"}}},{ranch,".*",{git,"https://github.com/ninenines/ranch",{tag,"1.8.1"}}}
 ]}.
 {erl_opts, [debug_info,warn_export_vars,warn_shadow_vars,warn_obsolete_guard,warn_missing_spec,warn_untyped_record]}.

--- a/src/cowboy_websocket_linger.erl
+++ b/src/cowboy_websocket_linger.erl
@@ -628,8 +628,10 @@ handler_call_result(State0, HandlerState, ParseState, NextState, Commands) ->
 			websocket_closed(State, HandlerState, Reason);
 		{stop, State} ->
 			stop(State, HandlerState);
-		{{error, Reason}, State} ->
-			websocket_closed(State, HandlerState, Reason)
+		{{error, closed}, State} ->
+			websocket_closed(State, HandlerState, {error, sock_closed});
+		{{error, _} = Error, State} ->
+			websocket_closed(State, HandlerState, Error)
 	end.
 
 commands([], State, []) ->

--- a/src/cowboy_websocket_linger.erl
+++ b/src/cowboy_websocket_linger.erl
@@ -435,6 +435,8 @@ loop(State=#state{parent=Parent, socket=Socket, messages=Messages,
 		{OK, Socket, Data} when OK =:= element(1, Messages) ->
 			State1 = maybe_resize_buffer(State, Data),
 			parse(?reset_idle_timeout(State1), HandlerState, ParseState, Data);
+		{Closed, Socket} when Closed =:= element(2, Messages) andalso ParseState =:= closed ->
+			loop(State, HandlerState, ParseState);
 		{Closed, Socket} when Closed =:= element(2, Messages) ->
 			%% WS-LINGER
 			websocket_closed(State, HandlerState, {error, sock_closed}, fun closed_loop/2);

--- a/src/cowboy_websocket_linger.erl
+++ b/src/cowboy_websocket_linger.erl
@@ -662,6 +662,8 @@ commands([{set_options, SetOpts}|Tail], State0, Data) ->
 			StateF
 	end, State0, SetOpts),
 	commands(Tail, State, Data);
+commands([{shutdown_reason, ShutdownReason}|Tail], State, Data) ->
+	commands(Tail, State#state{shutdown_reason=ShutdownReason}, Data);
 commands([{shutdown, Reason}|_Tail], State, Data) ->
 	%% WS-LINGER
 	_ = Data =/= [] andalso transport_send(State, fin, lists:reverse(Data)),

--- a/src/cowboy_websocket_linger.erl
+++ b/src/cowboy_websocket_linger.erl
@@ -626,8 +626,8 @@ handler_call_result(State0, HandlerState, ParseState, NextState, Commands) ->
 			websocket_closed(State, HandlerState, Reason);
 		{stop, State} ->
 			stop(State, HandlerState);
-		{Error = {error, _}, State} ->
-			websocket_close(State, HandlerState, Error)
+		{{error, Reason}, State} ->
+			websocket_closed(State, HandlerState, Reason)
 	end.
 
 commands([], State, []) ->

--- a/test/cowboy_test_ws.erl
+++ b/test/cowboy_test_ws.erl
@@ -1,0 +1,11 @@
+%% Feel free to use, reuse and abuse the code in this file.
+
+-module(cowboy_test_ws).
+-compile(export_all).
+-compile(nowarn_export_all).
+
+module(Opts) ->
+    proplists:get_value(cowboy_ws_module, Opts, cowboy_websocket).
+
+mkopts(Module) ->
+	[{cowboy_ws_module, Module}].

--- a/test/handlers/ws_active_commands_h.erl
+++ b/test/handlers/ws_active_commands_h.erl
@@ -9,8 +9,8 @@
 -export([websocket_handle/2]).
 -export([websocket_info/2]).
 
-init(Req, RunOrHibernate) ->
-	{cowboy_websocket, Req, RunOrHibernate}.
+init(Req, [RunOrHibernate | Opts]) ->
+	{cowboy_test_ws:module(Opts), Req, RunOrHibernate}.
 
 websocket_init(State=run) ->
 	erlang:send_after(1500, self(), active_true),

--- a/test/handlers/ws_deflate_commands_h.erl
+++ b/test/handlers/ws_deflate_commands_h.erl
@@ -8,8 +8,8 @@
 -export([websocket_handle/2]).
 -export([websocket_info/2]).
 
-init(Req, RunOrHibernate) ->
-	{cowboy_websocket, Req,
+init(Req, [RunOrHibernate | Opts]) ->
+	{cowboy_test_ws:module(Opts), Req,
 		#{deflate => true, hibernate => RunOrHibernate},
 		#{compress => true}}.
 

--- a/test/handlers/ws_deflate_opts_h.erl
+++ b/test/handlers/ws_deflate_opts_h.erl
@@ -20,7 +20,7 @@ init(Req=#{qs := Qs}, State) ->
 		<<"mem_level">> -> {mem_level, 1};
 		<<"strategy">> -> {strategy, rle}
 	end,
-	{cowboy_websocket, Req, State, #{
+	{cowboy_test_ws:module(State), Req, State, #{
 		compress => true,
 		deflate_opts => #{Name => Value}
 	}}.

--- a/test/handlers/ws_dont_validate_utf8_h.erl
+++ b/test/handlers/ws_dont_validate_utf8_h.erl
@@ -8,7 +8,7 @@
 -export([websocket_info/2]).
 
 init(Req, State) ->
-	{cowboy_websocket, Req, State, #{
+	{cowboy_test_ws:module(State), Req, State, #{
 		validate_utf8 => false
 	}}.
 

--- a/test/handlers/ws_handle_commands_h.erl
+++ b/test/handlers/ws_handle_commands_h.erl
@@ -9,14 +9,14 @@
 -export([websocket_handle/2]).
 -export([websocket_info/2]).
 
-init(Req=#{pid := Pid}, RunOrHibernate) ->
+init(Req=#{pid := Pid}, [RunOrHibernate | Opts]) ->
 	Commands0 = cowboy_req:header(<<"x-commands">>, Req),
 	Commands = binary_to_term(base64:decode(Commands0)),
 	case Commands of
 		bad -> ct_helper_error_h:ignore(Pid, cowboy_websocket, handler_call, 6);
 		_ -> ok
 	end,
-	{cowboy_websocket, Req, {Commands, RunOrHibernate}}.
+	{cowboy_test_ws:module(Opts), Req, {Commands, RunOrHibernate}}.
 
 websocket_init(State) ->
 	{[], State}.

--- a/test/handlers/ws_handle_commands_h.erl
+++ b/test/handlers/ws_handle_commands_h.erl
@@ -13,7 +13,7 @@ init(Req=#{pid := Pid}, [RunOrHibernate | Opts]) ->
 	Commands0 = cowboy_req:header(<<"x-commands">>, Req),
 	Commands = binary_to_term(base64:decode(Commands0)),
 	case Commands of
-		bad -> ct_helper_error_h:ignore(Pid, cowboy_websocket, handler_call, 6);
+		bad -> ct_helper_error_h:ignore(Pid, cowboy_test_ws:module(Opts), handler_call, 6);
 		_ -> ok
 	end,
 	{cowboy_test_ws:module(Opts), Req, {Commands, RunOrHibernate}}.

--- a/test/handlers/ws_info_commands_h.erl
+++ b/test/handlers/ws_info_commands_h.erl
@@ -10,14 +10,14 @@
 -export([websocket_handle/2]).
 -export([websocket_info/2]).
 
-init(Req=#{pid := Pid}, RunOrHibernate) ->
+init(Req=#{pid := Pid}, [RunOrHibernate | Opts]) ->
 	Commands0 = cowboy_req:header(<<"x-commands">>, Req),
 	Commands = binary_to_term(base64:decode(Commands0)),
 	case Commands of
 		bad -> ct_helper_error_h:ignore(Pid, cowboy_websocket, handler_call, 6);
 		_ -> ok
 	end,
-	{cowboy_websocket, Req, {Commands, RunOrHibernate}}.
+	{cowboy_test_ws:module(Opts), Req, {Commands, RunOrHibernate}}.
 
 websocket_init(State) ->
 	self() ! shoot,

--- a/test/handlers/ws_info_commands_h.erl
+++ b/test/handlers/ws_info_commands_h.erl
@@ -14,7 +14,7 @@ init(Req=#{pid := Pid}, [RunOrHibernate | Opts]) ->
 	Commands0 = cowboy_req:header(<<"x-commands">>, Req),
 	Commands = binary_to_term(base64:decode(Commands0)),
 	case Commands of
-		bad -> ct_helper_error_h:ignore(Pid, cowboy_websocket, handler_call, 6);
+		bad -> ct_helper_error_h:ignore(Pid, cowboy_test_ws:module(Opts), handler_call, 6);
 		_ -> ok
 	end,
 	{cowboy_test_ws:module(Opts), Req, {Commands, RunOrHibernate}}.

--- a/test/handlers/ws_init_commands_h.erl
+++ b/test/handlers/ws_init_commands_h.erl
@@ -13,7 +13,7 @@ init(Req=#{pid := Pid}, [RunOrHibernate | Opts]) ->
 	Commands0 = cowboy_req:header(<<"x-commands">>, Req),
 	Commands = binary_to_term(base64:decode(Commands0)),
 	case Commands of
-		bad -> ct_helper_error_h:ignore(Pid, cowboy_websocket, handler_call, 6);
+		bad -> ct_helper_error_h:ignore(Pid, cowboy_test_ws:module(Opts), handler_call, 6);
 		_ -> ok
 	end,
 	{cowboy_test_ws:module(Opts), Req, {Commands, RunOrHibernate}}.

--- a/test/handlers/ws_init_commands_h.erl
+++ b/test/handlers/ws_init_commands_h.erl
@@ -9,14 +9,14 @@
 -export([websocket_handle/2]).
 -export([websocket_info/2]).
 
-init(Req=#{pid := Pid}, RunOrHibernate) ->
+init(Req=#{pid := Pid}, [RunOrHibernate | Opts]) ->
 	Commands0 = cowboy_req:header(<<"x-commands">>, Req),
 	Commands = binary_to_term(base64:decode(Commands0)),
 	case Commands of
 		bad -> ct_helper_error_h:ignore(Pid, cowboy_websocket, handler_call, 6);
 		_ -> ok
 	end,
-	{cowboy_websocket, Req, {Commands, RunOrHibernate}}.
+	{cowboy_test_ws:module(Opts), Req, {Commands, RunOrHibernate}}.
 
 websocket_init(State={Commands, run}) ->
 	{Commands, State};

--- a/test/handlers/ws_init_h.erl
+++ b/test/handlers/ws_init_h.erl
@@ -8,9 +8,9 @@
 -export([websocket_handle/2]).
 -export([websocket_info/2]).
 
-init(Req, _) ->
+init(Req, Opts) ->
 	State = binary_to_atom(cowboy_req:qs(Req), latin1),
-	{cowboy_websocket, Req, State}.
+	{cowboy_test_ws:module(Opts), Req, State}.
 
 %% Sleep to make sure the HTTP response was sent.
 websocket_init(State) ->

--- a/test/handlers/ws_linger_h.erl
+++ b/test/handlers/ws_linger_h.erl
@@ -1,0 +1,43 @@
+%% This module sends an empty ping to the client and
+%% waits for a pong before sending a text frame. It
+%% is used to confirm server-initiated pings work.
+
+-module(ws_linger_h).
+-behavior(cowboy_websocket_linger).
+
+-export([init/2]).
+-export([websocket_init/1]).
+-export([websocket_handle/2]).
+-export([websocket_info/2]).
+-export([websocket_close/2]).
+
+init(Req, RunOrHibernate) ->
+	TestPid = list_to_pid(binary_to_list(cowboy_req:header(<<"x-test-pid">>, Req))),
+	{cowboy_websocket_linger, Req, {TestPid, RunOrHibernate}, #{
+		active_n => 10
+	}}.
+
+websocket_init(State = {TestPid, RunOrHibernate}) ->
+	TestPid ! {?MODULE, self()},
+	case RunOrHibernate of
+		run -> {ok, State};
+		hibernate -> {ok, State, hibernate}
+	end.
+
+websocket_handle(_, State = {_, RunOrHibernate}) ->
+	Command = {binary, <<"ACK">>},
+	case RunOrHibernate of
+		run -> {[Command], State};
+		hibernate -> {[Command], State, hibernate}
+	end.
+
+websocket_info(thatsit, State = {_, RunOrHibernate}) ->
+	Commands = [{shutdown, thatsit}],
+	case RunOrHibernate of
+		run -> {Commands, State};
+		hibernate -> {Commands, State, hibernate}
+	end.
+
+websocket_close(Reason, State = {TestPid, _RunOrHibernate}) ->
+	TestPid ! {?MODULE, {websocket_close, Reason}},
+	{ok, State}.

--- a/test/handlers/ws_ping_h.erl
+++ b/test/handlers/ws_ping_h.erl
@@ -10,8 +10,8 @@
 -export([websocket_handle/2]).
 -export([websocket_info/2]).
 
-init(Req, _) ->
-	{cowboy_websocket, Req, undefined}.
+init(Req, Opts) ->
+	{cowboy_test_ws:module(Opts), Req, undefined}.
 
 websocket_init(State) ->
 	{[{ping, <<>>}], State}.

--- a/test/handlers/ws_set_options_commands_h.erl
+++ b/test/handlers/ws_set_options_commands_h.erl
@@ -7,8 +7,8 @@
 -export([websocket_handle/2]).
 -export([websocket_info/2]).
 
-init(Req, RunOrHibernate) ->
-	{cowboy_websocket, Req, RunOrHibernate,
+init(Req, [RunOrHibernate | Opts]) ->
+	{cowboy_test_ws:module(Opts), Req, RunOrHibernate,
 		#{idle_timeout => infinity}}.
 
 %% Set the idle_timeout option dynamically.

--- a/test/handlers/ws_shutdown_reason_commands_h.erl
+++ b/test/handlers/ws_shutdown_reason_commands_h.erl
@@ -10,9 +10,9 @@
 -export([websocket_handle/2]).
 -export([websocket_info/2]).
 
-init(Req, RunOrHibernate) ->
+init(Req, [RunOrHibernate | Opts]) ->
 	TestPid = list_to_pid(binary_to_list(cowboy_req:header(<<"x-test-pid">>, Req))),
-	{cowboy_websocket, Req, {TestPid, RunOrHibernate}}.
+	{cowboy_test_ws:module(Opts), Req, {TestPid, RunOrHibernate}}.
 
 websocket_init(State={TestPid, RunOrHibernate}) ->
 	TestPid ! {ws_pid, self()},

--- a/test/handlers/ws_terminate_h.erl
+++ b/test/handlers/ws_terminate_h.erl
@@ -13,13 +13,13 @@
 	pid
 }).
 
-init(Req, _) ->
+init(Req, HOpts) ->
 	Pid = list_to_pid(binary_to_list(cowboy_req:header(<<"x-test-pid">>, Req))),
 	Opts = case cowboy_req:qs(Req) of
 		<<"req_filter">> -> #{req_filter => fun(_) -> filtered end};
 		_ -> #{}
 	end,
-	{cowboy_websocket, Req, #state{pid=Pid}, Opts}.
+	{cowboy_test_ws:module(HOpts), Req, #state{pid=Pid}, Opts}.
 
 websocket_init(State) ->
 	{ok, State}.

--- a/test/ws_SUITE.erl
+++ b/test/ws_SUITE.erl
@@ -22,54 +22,61 @@
 %% ct.
 
 all() ->
-	[{group, ws}].
+	[{group, ws}, {group, ws_linger}].
 
 groups() ->
-	[{ws, [parallel], ct_helper:all(?MODULE)}].
+	[
+		{ws,        [parallel], ct_helper:all(?MODULE)},
+		{ws_linger, [parallel], ct_helper:all(?MODULE)}
+	].
 
 init_per_group(Name, Config) ->
 	cowboy_test:init_http(Name, #{
-		env => #{dispatch => init_dispatch()}
-	}, Config).
+		env => #{dispatch => init_dispatch(Name)}
+	}, [{ct_group, Name} | Config]).
 
 end_per_group(Listener, _Config) ->
 	cowboy:stop_listener(Listener).
 
 %% Dispatch configuration.
 
-init_dispatch() ->
+init_dispatch(Name) ->
+	Opts = case Name of
+		ws ->        cowboy_test_ws:mkopts(cowboy_websocket);
+		ws_linger -> cowboy_test_ws:mkopts(cowboy_websocket_linger)
+	end,
 	cowboy_router:compile([
 		{"localhost", [
-			{"/ws_echo", ws_echo, []},
-			{"/ws_echo_timer", ws_echo_timer, []},
-			{"/ws_init", ws_init_h, []},
-			{"/ws_init_shutdown", ws_init_shutdown, []},
+			{"/ws_echo", ws_echo, Opts},
+			{"/ws_echo_timer", ws_echo_timer, Opts},
+			{"/ws_init", ws_init_h, Opts},
+			{"/ws_init_shutdown", ws_init_shutdown, Opts},
 			{"/ws_send_many", ws_send_many, [
 				{sequence, [
 					{text, <<"one">>},
 					{text, <<"two">>},
-					{text, <<"seven!">>}]}
+					{text, <<"seven!">>}]} | Opts
 			]},
 			{"/ws_send_close", ws_send_many, [
 				{sequence, [
 					{text, <<"send">>},
 					close,
-					{text, <<"won't be received">>}]}
+					{text, <<"won't be received">>}]} | Opts
 			]},
 			{"/ws_send_close_payload", ws_send_many, [
 				{sequence, [
 					{text, <<"send">>},
 					{close, 1001, <<"some text!">>},
-					{text, <<"won't be received">>}]}
+					{text, <<"won't be received">>}]} | Opts
 			]},
-			{"/ws_subprotocol", ws_subprotocol, []},
-			{"/terminate", ws_terminate_h, []},
-			{"/ws_timeout_hibernate", ws_timeout_hibernate, []},
-			{"/ws_timeout_cancel", ws_timeout_cancel, []},
-			{"/ws_max_frame_size", ws_max_frame_size, []},
-			{"/ws_deflate_opts", ws_deflate_opts_h, []},
-			{"/ws_dont_validate_utf8", ws_dont_validate_utf8_h, []},
-			{"/ws_ping", ws_ping_h, []}
+			{"/ws_subprotocol", ws_subprotocol, Opts},
+			{"/terminate", ws_terminate_h, Opts},
+			{"/ws_timeout_hibernate", ws_timeout_hibernate, Opts},
+			{"/ws_timeout_cancel", ws_timeout_cancel, Opts},
+			{"/ws_max_frame_size", ws_max_frame_size, Opts},
+			{"/ws_deflate_opts", ws_deflate_opts_h, Opts},
+			{"/ws_dont_validate_utf8", ws_dont_validate_utf8_h, Opts},
+			{"/ws_ping", ws_ping_h, Opts}
 		]}
 	]).
 
@@ -100,7 +107,8 @@ do_unlimited_connections(Config) ->
 	%% We have at least 3000 client and 3000 server sockets.
 	true = length(erlang:ports()) > 6000,
 	%% Ranch thinks we have no connections.
-	0 = ranch_server:count_connections(ws),
+	Listener = proplists:get_value(ct_group, Config),
+	0 = ranch_server:count_connections(Listener),
 	ok.
 
 do_connect_and_loop(Config) ->

--- a/test/ws_SUITE_data/ws_echo.erl
+++ b/test/ws_SUITE_data/ws_echo.erl
@@ -6,8 +6,8 @@
 -export([websocket_handle/2]).
 -export([websocket_info/2]).
 
-init(Req, _) ->
-	{cowboy_websocket, Req, undefined, #{
+init(Req, Opts) ->
+	{cowboy_test_ws:module(Opts), Req, undefined, #{
 		compress => true
 	}}.
 

--- a/test/ws_SUITE_data/ws_echo_timer.erl
+++ b/test/ws_SUITE_data/ws_echo_timer.erl
@@ -7,8 +7,8 @@
 -export([websocket_handle/2]).
 -export([websocket_info/2]).
 
-init(Req, _) ->
-	{cowboy_websocket, Req, undefined}.
+init(Req, Opts) ->
+	{cowboy_test_ws:module(Opts), Req, undefined}.
 
 websocket_init(State) ->
 	erlang:start_timer(1000, self(), <<"websocket_init">>),

--- a/test/ws_SUITE_data/ws_max_frame_size.erl
+++ b/test/ws_SUITE_data/ws_max_frame_size.erl
@@ -5,7 +5,10 @@
 -export([websocket_info/2]).
 
 init(Req, State) ->
-	{cowboy_websocket, Req, State, #{max_frame_size => 8, compress => true}}.
+	{cowboy_test_ws:module(State), Req, State, #{
+		max_frame_size => 8,
+		compress => true
+	}}.
 
 websocket_handle({text, Data}, State) ->
 	{[{text, Data}], State};

--- a/test/ws_SUITE_data/ws_send_many.erl
+++ b/test/ws_SUITE_data/ws_send_many.erl
@@ -8,7 +8,8 @@
 -export([websocket_info/2]).
 
 init(Req, Opts) ->
-	{cowboy_websocket, Req, Opts}.
+	Sequence = proplists:get_value(sequence, Opts),
+	{cowboy_test_ws:module(Opts), Req, Sequence}.
 
 websocket_init(State) ->
 	erlang:send_after(10, self(), send_many),
@@ -17,5 +18,5 @@ websocket_init(State) ->
 websocket_handle(_Frame, State) ->
 	{[], State}.
 
-websocket_info(send_many, State = [{sequence, Sequence}]) ->
-	{Sequence, State}.
+websocket_info(send_many, Sequence) ->
+	{Sequence, _State = Sequence}.

--- a/test/ws_SUITE_data/ws_subprotocol.erl
+++ b/test/ws_SUITE_data/ws_subprotocol.erl
@@ -9,7 +9,7 @@
 init(Req, Opts) ->
 	[Protocol | _] = cowboy_req:parse_header(<<"sec-websocket-protocol">>, Req),
 	Req2 = cowboy_req:set_resp_header(<<"sec-websocket-protocol">>, Protocol, Req),
-	{cowboy_websocket, Req2, Opts, #{
+	{cowboy_test_ws:module(Opts), Req2, Opts, #{
 		idle_timeout => 1000
 	}}.
 

--- a/test/ws_SUITE_data/ws_timeout_cancel.erl
+++ b/test/ws_SUITE_data/ws_timeout_cancel.erl
@@ -6,9 +6,9 @@
 -export([websocket_handle/2]).
 -export([websocket_info/2]).
 
-init(Req, _) ->
+init(Req, Opts) ->
 	erlang:start_timer(500, self(), should_not_cancel_timer),
-	{cowboy_websocket, Req, undefined, #{
+	{cowboy_test_ws:module(Opts), Req, undefined, #{
 		idle_timeout => 1000
 	}}.
 

--- a/test/ws_SUITE_data/ws_timeout_hibernate.erl
+++ b/test/ws_SUITE_data/ws_timeout_hibernate.erl
@@ -7,8 +7,8 @@
 -export([websocket_handle/2]).
 -export([websocket_info/2]).
 
-init(Req, _) ->
-	{cowboy_websocket, Req, undefined, #{
+init(Req, Opts) ->
+	{cowboy_test_ws:module(Opts), Req, undefined, #{
 		idle_timeout => 1000
 	}}.
 

--- a/test/ws_handler_SUITE.erl
+++ b/test/ws_handler_SUITE.erl
@@ -34,10 +34,14 @@ all() ->
 %% @todo Test against HTTP/2 too.
 groups() ->
 	AllTests = ct_helper:all(?MODULE),
+	LingerTests = [
+		websocket_linger_closed_shutdown,
+		websocket_linger_already_closed
+	],
 	[
-		{ws, [parallel], AllTests},
+		{ws, [parallel], AllTests -- LingerTests},
 		{ws_linger, [parallel], AllTests},
-		{ws_hibernate, [parallel], AllTests},
+		{ws_hibernate, [parallel], AllTests -- LingerTests},
 		{ws_linger_hibernate, [parallel], AllTests}
 	].
 
@@ -73,7 +77,8 @@ init_dispatch(Name) ->
 		{"/active", ws_active_commands_h, Opts},
 		{"/deflate", ws_deflate_commands_h, Opts},
 		{"/set_options", ws_set_options_commands_h, Opts},
-		{"/shutdown_reason", ws_shutdown_reason_commands_h, Opts}
+		{"/shutdown_reason", ws_shutdown_reason_commands_h, Opts},
+		{"/linger", ws_linger_h, RunOrHibernate}
 	]}]).
 
 %% Support functions for testing using Gun.
@@ -366,4 +371,51 @@ websocket_shutdown_reason(Config) ->
 			ok
 	after 1000 ->
 		error(timeout)
+	end.
+
+websocket_linger_closed_shutdown(Config) ->
+	do_websocket_linger_closed_shutdown(normal, Config).
+
+websocket_linger_already_closed(Config) ->
+	do_websocket_linger_closed_shutdown(suspend, Config).
+
+do_websocket_linger_closed_shutdown(Mode, Config) ->
+	doc("Lingering WebSocket smoothly handles frames for already "
+        "closed connections."),
+	ConnPid = gun_open(Config),
+	StreamRef = gun:ws_upgrade(ConnPid, "/linger", [
+		{<<"x-test-pid">>, pid_to_list(self())}
+	]),
+	{upgrade, [<<"websocket">>], _} = gun:await(ConnPid, StreamRef),
+	WsPid = receive {ws_linger_h, P} -> P after 1000 -> error(timeout) end,
+	MRef = monitor(process, WsPid),
+	case Mode of
+		normal -> ok;
+		suspend -> sys:suspend(WsPid)
+	end,
+	ok = gun:ws_send(ConnPid, StreamRef, [{binary, <<"CIAO">>}]),
+	_ = timer:sleep(50),
+	_ = erlang:exit(ConnPid, shutdown),
+	_ = timer:sleep(50),
+	case Mode of
+		normal -> ok;
+		suspend -> sys:resume(WsPid)
+	end,
+	receive
+		{ws_linger_h, {websocket_close, Reason}} ->
+			{error, sock_closed} = Reason
+	after 1000 ->
+		error(timeout)
+	end,
+	receive
+		{'DOWN', MRef, process, WsPid, ExitReason} ->
+			error({unexpected_exit, WsPid, ExitReason})
+	after 1000 ->
+		WsPid ! thatsit,
+		receive
+			{'DOWN', MRef, process, WsPid, ExitReason} ->
+				{shutdown, thatsit} = ExitReason
+		after 1000 ->
+			error(timeout)
+		end
 	end.

--- a/test/ws_handler_SUITE.erl
+++ b/test/ws_handler_SUITE.erl
@@ -24,12 +24,22 @@
 %% ct.
 
 all() ->
-	[{group, ws}, {group, ws_hibernate}].
+	[
+		{group, ws},
+		{group, ws_linger},
+		{group, ws_hibernate},
+		{group, ws_linger_hibernate}
+	].
 
 %% @todo Test against HTTP/2 too.
 groups() ->
 	AllTests = ct_helper:all(?MODULE),
-	[{ws, [parallel], AllTests}, {ws_hibernate, [parallel], AllTests}].
+	[
+		{ws, [parallel], AllTests},
+		{ws_linger, [parallel], AllTests},
+		{ws_hibernate, [parallel], AllTests},
+		{ws_linger_hibernate, [parallel], AllTests}
+	].
 
 init_per_group(Name, Config) ->
 	cowboy_test:init_http(Name, #{
@@ -44,17 +54,26 @@ end_per_group(Name, _) ->
 init_dispatch(Name) ->
 	RunOrHibernate = case Name of
 		ws -> run;
-		ws_hibernate -> hibernate
+		ws_linger -> run;
+		ws_hibernate -> hibernate;
+		ws_linger_hibernate -> hibernate
 	end,
+	Module = case Name of
+		ws -> cowboy_websocket;
+		ws_linger -> cowboy_websocket_linger;
+		ws_hibernate -> cowboy_websocket;
+		ws_linger_hibernate -> cowboy_websocket_linger
+	end,
+	Opts = [RunOrHibernate | cowboy_test_ws:mkopts(Module)],
 	cowboy_router:compile([{'_', [
-		{"/init", ws_init_commands_h, RunOrHibernate},
-		{"/handle", ws_handle_commands_h, RunOrHibernate},
-		{"/info", ws_info_commands_h, RunOrHibernate},
-		{"/trap_exit", ws_init_h, RunOrHibernate},
-		{"/active", ws_active_commands_h, RunOrHibernate},
-		{"/deflate", ws_deflate_commands_h, RunOrHibernate},
-		{"/set_options", ws_set_options_commands_h, RunOrHibernate},
-		{"/shutdown_reason", ws_shutdown_reason_commands_h, RunOrHibernate}
+		{"/init", ws_init_commands_h, Opts},
+		{"/handle", ws_handle_commands_h, Opts},
+		{"/info", ws_info_commands_h, Opts},
+		{"/trap_exit", ws_init_h, Opts},
+		{"/active", ws_active_commands_h, Opts},
+		{"/deflate", ws_deflate_commands_h, Opts},
+		{"/set_options", ws_set_options_commands_h, Opts},
+		{"/shutdown_reason", ws_shutdown_reason_commands_h, Opts}
 	]}]).
 
 %% Support functions for testing using Gun.


### PR DESCRIPTION
This helps to avoid situations leading to connection crashes similar to the following:
```
crasher: initial call: cowboy_tls:connection_process/4,
error: {{case_clause,{error,closed}},[
    {cowboy_websocket_linger,websocket_send_close,2,[{file,"cowboy_websocket_linger.erl"},{line,752}]},
    {cowboy_websocket_linger,websocket_close,3,[{file,"cowboy_websocket_linger.erl"},{line,743}]},
    {proc_lib,wake_up,3,[{file,"proc_lib.erl"},{line,340}]}
]},
messages: [
    {ssl,{sslsocket,{gen_tcp,#Port<...>,...},[...]},<<130,130,27,93,145,101,251,93>>},
    {ssl_closed,{sslsocket,{gen_tcp,#Port<...>,...},[...]}}
],
...
```

See individual commits for details.

Fixes [EMQX-14990](https://emqx.atlassian.net/browse/EMQX-14990).